### PR TITLE
fix: record a partial manifest when a rollout fails midway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/zhchang/goquiver v1.0.21
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.29.3
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -184,5 +185,4 @@ require (
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -294,9 +294,14 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 	if len(new) == 0 {
 		return fmt.Errorf("nothing to rollout")
 	}
-	// Captured before apply, which renames StatefulSet entries in place. Reads of the
-	// manifest are keyed by the release name, so the record must be too.
-	manifestName := new[0].GetName()
+	// The release name, which is what getExistingManifest and Remove key their reads by.
+	// new[0].GetName() is not a safe substitute: helm does not guarantee the first
+	// rendered object is named exactly global.name, and a chart whose first resource is
+	// e.g. "<release>-sa" would have its manifest written somewhere nothing looks.
+	var manifestName string
+	if manifestName, err = raw.ChainGet[string](values, "global", "name"); err != nil {
+		return err
+	}
 
 	var toRemoves []toRemove
 	var changed = map[string]bool{}
@@ -417,6 +422,16 @@ func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resourc
 		rc.Logger().Warnf("failed to encode partial manifest for %s/%s: %s", rc.Namespace(), name, err)
 		return
 	}
+	// DecodeAllYAML splits on the substring "---", so a resource carrying one in its
+	// content - a PEM block, an embedded manifest - does not survive the round trip.
+	// Never replace a readable manifest with one that cannot be read back: uninstall
+	// would then fail to decode it and delete nothing at all.
+	var decoded []k8s.Resource
+	if decoded, err = k8s.DecodeAllYAML(value); err != nil || len(decoded) != len(merged) {
+		rc.Logger().Warnf("partial manifest for %s/%s does not round-trip (%d of %d resources, err: %v), leaving the existing manifest untouched",
+			rc.Namespace(), name, len(decoded), len(merged), err)
+		return
+	}
 	if err = writeManifest(rc.Context(), value, name, rc.Namespace()); err != nil {
 		rc.Logger().Warnf("failed to write partial manifest for %s/%s: %s", rc.Namespace(), name, err)
 		return
@@ -496,19 +511,13 @@ func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, 
 		}
 		rc.Logger().Debugf(`applyManifest going for item: %s,conditons: %t,%t`, key, didChange, exists)
 		if err = applyResource(rc.Context(), r, k8s.WithWait(wait)); err != nil {
-			// k8s.Rollout creates or updates before it waits for readiness, so when a
-			// wait was requested the object may well exist despite this error. Record
-			// such a resource if it is new to us: an entry for something absent is
-			// harmless to uninstall, which only warns, while a missing entry leaks.
-			// Resources already in the recorded manifest are deliberately left at their
-			// old form so a retry still diffs against what is really deployed.
-			//
-			// The lookup uses the canonical name: `key` above is the post-renameStss
-			// name, which for a StatefulSet never matches the canonical name `changed`
-			// was populated under, so it would report every StatefulSet as new.
-			if _, known := changed[resourceKey(kind, canonical[i].GetName())]; wait > 0 && !known {
-				applied = append(applied, canonical[i])
-			}
+			// Deliberately not recorded. k8s.Rollout creates before it waits for
+			// readiness, so a failed wait can leave the object behind and that one does
+			// leak until the next successful rollout records it. Recording it anyway
+			// would be worse: we cannot tell that case apart from an admission or
+			// validation rejection where nothing was created, and recording a resource
+			// that does not exist makes the next rollout diff it against itself, skip
+			// it, and report success while it stays missing.
 			return
 		}
 		applied = append(applied, canonical[i])

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -354,8 +354,11 @@ var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.Ope
 // decodeAllYAML is a seam over k8s.DecodeAllYAML for the round trip check below.
 var decodeAllYAML = k8s.DecodeAllYAML
 
-// manifestWriteTimeout bounds the detached write of a partial manifest.
-const manifestWriteTimeout = 30 * time.Second
+// manifestWriteTimeout bounds the detached write of a partial manifest. Because the
+// write ignores the caller's cancellation, this is also the worst case delay it can add
+// to Rollout returning its error - keep it comfortably above a single ConfigMap write
+// but short enough not to drag out a shutdown.
+const manifestWriteTimeout = 10 * time.Second
 
 // mergeResources overlays applied on top of old, keyed by namespace+kind+name.
 //

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -14,12 +14,15 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nextbillion-ai/goreman-util/global"
 	"github.com/zhchang/goquiver/k8s"
 	"github.com/zhchang/goquiver/raw"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 type toRemove struct {
@@ -291,6 +294,9 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 	if len(new) == 0 {
 		return fmt.Errorf("nothing to rollout")
 	}
+	// Captured before apply, which renames StatefulSet entries in place. Reads of the
+	// manifest are keyed by the release name, so the record must be too.
+	manifestName := new[0].GetName()
 
 	var toRemoves []toRemove
 	var changed = map[string]bool{}
@@ -324,13 +330,97 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 	if !rotated {
 		opts.wait = time.Duration(0)
 	}
-	if err = apply(rc, new, toRemoves, opts.wait, changed); err != nil {
+	var applied []k8s.Resource
+	if applied, err = apply(rc, new, toRemoves, opts.wait, changed); err != nil {
+		// The rollout stopped part way through, so the full desired manifest would be a
+		// lie: writing it would both hide resources from uninstall and make the next
+		// retry believe everything is already applied. Record what is actually there.
+		recordPartialManifest(rc, old, applied, manifestName)
 		return err
 	}
 	return writeManifest(rc.Context(), newStr, new[0].GetName(), rc.Namespace())
 }
 
-func writeManifest(ctx context.Context, value, name, namespace string) error {
+// applyResource is a seam over k8s.Rollout so that tests can drive partial failures.
+var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.OperationOption) error {
+	return k8s.Rollout(ctx, r, options...)
+}
+
+// mergeResources overlays applied on top of old, keyed by kind+name.
+//
+// Resources that were never applied stay at their old recorded form, which is exactly
+// what is still running in the cluster: an update that failed leaves the previous object
+// intact, and a resource that was never reached was never touched. Old resources that are
+// absent from applied are kept so that uninstall still removes them.
+func mergeResources(old, applied []k8s.Resource) []k8s.Resource {
+	var merged []k8s.Resource
+	index := map[string]int{}
+	var add = func(r k8s.Resource) {
+		key := resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+		if i, ok := index[key]; ok {
+			merged[i] = r
+			return
+		}
+		index[key] = len(merged)
+		merged = append(merged, r)
+	}
+	for _, r := range old {
+		add(r)
+	}
+	for _, r := range applied {
+		add(r)
+	}
+	return merged
+}
+
+// encodeResources serializes resources back into a multi-document manifest.
+//
+// Unstructured resources - which is what both GenManifest and DecodeAllYAML produce - are
+// marshalled from their raw content so the result round-trips byte-for-byte. Encoding them
+// through their typed structs instead would inject defaulted fields such as
+// spec.template.metadata.creationTimestamp, which show up as spurious diffs on the next
+// rollout and can trigger an unwanted StatefulSet rotation.
+func encodeResources(list []k8s.Resource) (string, error) {
+	var docs []string
+	for _, r := range list {
+		var data []byte
+		var err error
+		if u, ok := r.(*unstructured.Unstructured); ok {
+			data, err = sigsyaml.Marshal(u.UnstructuredContent())
+		} else {
+			data, err = k8s.EncodeYAML(r)
+		}
+		if err != nil {
+			return "", err
+		}
+		docs = append(docs, strings.TrimSpace(string(data)))
+	}
+	return "---\n" + strings.Join(docs, "\n---\n") + "\n", nil
+}
+
+// recordPartialManifest persists what is known to exist after a failed rollout, so that a
+// later uninstall can still clean it up and a retry still sees the un-applied resources as
+// changed. Best effort: failures here are logged, never returned, so they cannot mask the
+// rollout error that caused them.
+func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resource, name string) {
+	merged := mergeResources(old, applied)
+	if len(merged) == 0 {
+		return
+	}
+	var value string
+	var err error
+	if value, err = encodeResources(merged); err != nil {
+		rc.Logger().Warnf("failed to encode partial manifest for %s/%s: %s", rc.Namespace(), name, err)
+		return
+	}
+	if err = writeManifest(rc.Context(), value, name, rc.Namespace()); err != nil {
+		rc.Logger().Warnf("failed to write partial manifest for %s/%s: %s", rc.Namespace(), name, err)
+		return
+	}
+	rc.Logger().Infof("recorded partial manifest for %s/%s with %d resource(s)", rc.Namespace(), name, len(merged))
+}
+
+var writeManifest = func(ctx context.Context, value, name, namespace string) error {
 
 	var manifest k8s.ConfigMap
 	manifest.Kind = k8s.KindConfigMap
@@ -361,11 +451,22 @@ func renameStss(list []k8s.Resource, stsNameToRealName map[string]string) {
 	}
 }
 
-func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, wait time.Duration, changed map[string]bool) (err error) {
+// apply rolls out the given resources and reports which of them are known to be present
+// in the cluster afterwards.
+//
+// The returned resources are the *canonical* ones, i.e. the pre-renameStss form, because
+// that is how the manifest ConfigMap is keyed. Callers use them to record what actually
+// landed when the rollout only partially succeeds.
+func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, wait time.Duration, changed map[string]bool) (applied []k8s.Resource, err error) {
+	// Snapshot before renameStss, which replaces StatefulSet entries in `new` with
+	// renamed copies. Index correspondence is preserved because it assigns in place.
+	canonical := make([]k8s.Resource, len(new))
+	copy(canonical, new)
+
 	stsNameToRealName := map[string]string{}
 	renameStss(new, stsNameToRealName)
 
-	for _, r := range new {
+	for i, r := range new {
 		kind := r.GetObjectKind().GroupVersionKind().Kind
 		key := resourceKey(kind, r.GetName())
 		if kind == k8s.KindHorizontalPodAutoscaler {
@@ -385,12 +486,15 @@ func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, 
 		var didChange, exists bool
 		if didChange, exists = changed[key]; exists && !didChange {
 			rc.Logger().Infof(`applyManifest skipped for item: %s`, key)
+			// Unchanged relative to the recorded manifest, so it is already present.
+			applied = append(applied, canonical[i])
 			continue
 		}
 		rc.Logger().Debugf(`applyManifest going for item: %s,conditons: %t,%t`, key, didChange, exists)
-		if err = k8s.Rollout(rc.Context(), r, k8s.WithWait(wait)); err != nil {
+		if err = applyResource(rc.Context(), r, k8s.WithWait(wait)); err != nil {
 			return
 		}
+		applied = append(applied, canonical[i])
 	}
 
 	for _, r := range toRemoves {

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -363,8 +363,21 @@ const manifestWriteTimeout = 10 * time.Second
 // uninstall dispatches on. The namespace is included even though resourceKey elsewhere
 // ignores it, because the manifest is rewritten wholesale here - collapsing two
 // same-named resources from different namespaces would silently drop one and leak it.
-func manifestKey(r k8s.Resource) string {
-	return r.GetNamespace() + "/" + resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+//
+// Everything that keys into a manifest goes through here, so a resource and the removal
+// referring to it cannot disagree about their identity.
+func manifestKey(namespace, kind, name string) string {
+	return namespace + "/" + resourceKey(kind, name)
+}
+
+// keyOf is manifestKey for an already-decoded resource.
+func keyOf(r k8s.Resource) string {
+	return manifestKey(r.GetNamespace(), r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+}
+
+// key is manifestKey for a pending removal.
+func (t toRemove) key() string {
+	return manifestKey(t.namespace, t.kind, t.name)
 }
 
 // mergeResources overlays applied on top of old, keyed by manifestKey.
@@ -377,7 +390,7 @@ func mergeResources(old, applied []k8s.Resource) []k8s.Resource {
 	var merged []k8s.Resource
 	index := map[string]int{}
 	var add = func(r k8s.Resource) {
-		key := manifestKey(r)
+		key := keyOf(r)
 		if i, ok := index[key]; ok {
 			merged[i] = r
 			return
@@ -440,25 +453,23 @@ func encodeManifest(list []k8s.Resource) (string, error) {
 	return value, nil
 }
 
-// resourcesFor picks the recorded resources matching the given removals.
+// resourcesMatching returns the recorded resources the given removals refer to, in
+// recorded order so the manifest stays stable.
 //
-// Removals carrying a rotation suffix have no manifest entry of their own - the manifest
-// holds the canonical StatefulSet name - so they simply do not match, which is correct.
-func resourcesFor(recorded []k8s.Resource, removals []toRemove) []k8s.Resource {
-	if len(removals) == 0 {
-		return nil
+// A removal carrying a rotation suffix has no manifest entry of its own - the manifest
+// holds the canonical StatefulSet name - so it matches nothing, which is correct.
+func resourcesMatching(recorded []k8s.Resource, removals []toRemove) []k8s.Resource {
+	wanted := make(map[string]bool, len(removals))
+	for _, t := range removals {
+		wanted[t.key()] = true
 	}
-	wanted := map[string]bool{}
-	for _, r := range removals {
-		wanted[r.namespace+"/"+resourceKey(r.kind, r.name)] = true
-	}
-	var kept []k8s.Resource
+	var matched []k8s.Resource
 	for _, r := range recorded {
-		if wanted[manifestKey(r)] {
-			kept = append(kept, r)
+		if wanted[keyOf(r)] {
+			matched = append(matched, r)
 		}
 	}
-	return kept
+	return matched
 }
 
 // finalManifest returns the manifest to record after a successful rollout.
@@ -472,7 +483,7 @@ func resourcesFor(recorded []k8s.Resource, removals []toRemove) []k8s.Resource {
 // been written before this existed: the failed removals stop being tracked, but
 // everything else stays correct.
 func finalManifest(rc global.ResourceContext, old, applied []k8s.Resource, failedRemovals []toRemove, rendered, name string) string {
-	kept := resourcesFor(old, failedRemovals)
+	kept := resourcesMatching(old, failedRemovals)
 	if len(kept) == 0 {
 		return rendered
 	}

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -361,21 +361,20 @@ var decodeAllYAML = k8s.DecodeAllYAML
 // but short enough not to drag out a shutdown.
 const manifestWriteTimeout = 10 * time.Second
 
-// mergeResources overlays applied on top of old, keyed by namespace+kind+name.
+// manifestKey identifies one resource within a manifest document set: the triple that
+// uninstall dispatches on. The namespace is included even though resourceKey elsewhere
+// ignores it, because the manifest is rewritten wholesale here - collapsing two
+// same-named resources from different namespaces would silently drop one and leak it.
+func manifestKey(r k8s.Resource) string {
+	return r.GetNamespace() + "/" + resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+}
+
+// mergeResources overlays applied on top of old, keyed by manifestKey.
 //
 // Resources that were never applied stay at their old recorded form, which is exactly
 // what is still running in the cluster: an update that failed leaves the previous object
 // intact, and a resource that was never reached was never touched. Old resources that are
 // absent from applied are kept so that uninstall still removes them.
-//
-// The namespace is part of the key even though resourceKey elsewhere ignores it: this
-// rewrites the manifest, so collapsing two same-named resources from different namespaces
-// would silently drop one of them and leak it forever.
-// manifestKey identifies a resource within a manifest document set.
-func manifestKey(r k8s.Resource) string {
-	return r.GetNamespace() + "/" + resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
-}
-
 func mergeResources(old, applied []k8s.Resource) []k8s.Resource {
 	var merged []k8s.Resource
 	index := map[string]int{}

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -352,9 +352,6 @@ var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.Ope
 	return k8s.Rollout(ctx, r, options...)
 }
 
-// decodeAllYAML is a seam over k8s.DecodeAllYAML for the round trip check below.
-var decodeAllYAML = k8s.DecodeAllYAML
-
 // manifestWriteTimeout bounds the detached write of a partial manifest. Because the
 // write ignores the caller's cancellation, this is also the worst case delay it can add
 // to Rollout returning its error - keep it comfortably above a single ConfigMap write
@@ -436,28 +433,17 @@ func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resourc
 		rc.Logger().Warnf("failed to encode partial manifest for %s/%s: %s", rc.Namespace(), name, err)
 		return
 	}
-	// Sanity check, not a fix for a known input. Every other manifest write stores a
-	// string DecodeAllYAML had just parsed successfully - GenManifest decodes helm's
-	// output, getExistingManifest decodes the stored copy - so the text is proven
-	// readable before it is stored. encodeResources is the one route that generates
-	// manifest text afresh, and this write replaces the existing record, so confirm it
-	// reads back before destroying what is already there. DecodeAllYAML splits on the
-	// substring "---", so a value that re-marshals to contain one would not survive.
+	// Cheap assertion on a novel code path, not a fix for any input we can produce.
+	// Every other manifest write stores a string DecodeAllYAML had just parsed -
+	// GenManifest decodes helm's output, getExistingManifest decodes the stored copy -
+	// so it is known readable. encodeResources is the one route that serializes afresh,
+	// and this write replaces the existing record, so do not overwrite a readable
+	// manifest with something that cannot be read back.
 	var decoded []k8s.Resource
-	if decoded, err = decodeAllYAML(value); err != nil || len(decoded) != len(merged) {
+	if decoded, err = k8s.DecodeAllYAML(value); err != nil || len(decoded) != len(merged) {
 		rc.Logger().Warnf("partial manifest for %s/%s does not round-trip (%d of %d resources, err: %v), leaving the existing manifest untouched",
 			rc.Namespace(), name, len(decoded), len(merged), err)
 		return
-	}
-	// Matching counts alone is not enough: a stray "---" can split one document into
-	// fragments while another is dropped as empty, landing back on the same total. What
-	// uninstall acts on is each document's identity, so verify those.
-	for i, r := range decoded {
-		if manifestKey(r) != manifestKey(merged[i]) {
-			rc.Logger().Warnf("partial manifest for %s/%s round-trips to different resources (%s != %s), leaving the existing manifest untouched",
-				rc.Namespace(), name, manifestKey(r), manifestKey(merged[i]))
-			return
-		}
 	}
 	// Detach from the rollout's context. A cancelled or timed out context is itself a
 	// reason a rollout fails, and inheriting it here would mean the one case where the

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -337,12 +337,29 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 		opts.wait = time.Duration(0)
 	}
 	var applied []k8s.Resource
-	if applied, err = apply(rc, new, toRemoves, opts.wait, changed); err != nil {
+	var failedRemovals []toRemove
+	if applied, failedRemovals, err = apply(rc, new, toRemoves, opts.wait, changed); err != nil {
 		// The rollout stopped part way through, so the full desired manifest would be a
 		// lie: writing it would both hide resources from uninstall and make the next
 		// retry believe everything is already applied. Record what is actually there.
 		recordPartialManifest(rc, old, applied, manifestName)
 		return err
+	}
+	// A resource whose deletion failed is still running, so it has to stay in the
+	// manifest. Writing the desired manifest alone would drop it, and nothing would ever
+	// delete it again. On success `applied` is every rendered resource in canonical
+	// form, so the two merge cleanly.
+	if kept := resourcesFor(old, failedRemovals); len(kept) > 0 {
+		var value string
+		if value, err = encodeManifest(mergeResources(applied, kept)); err != nil {
+			// Fall back to the desired manifest, which is what would have been written
+			// before this existed. The failed removals leak, but adds stay tracked.
+			rc.Logger().Warnf("could not record %d resource(s) whose removal failed for %s/%s, they will no longer be tracked: %s",
+				len(kept), rc.Namespace(), manifestName, err)
+		} else {
+			rc.Logger().Infof("keeping %d resource(s) whose removal failed in the manifest for %s/%s", len(kept), rc.Namespace(), manifestName)
+			return writeManifest(rc.Context(), value, manifestName, rc.Namespace())
+		}
 	}
 	return writeManifest(rc.Context(), newStr, manifestName, rc.Namespace())
 }
@@ -418,6 +435,48 @@ func encodeResources(list []k8s.Resource) (string, error) {
 	return "---\n" + strings.Join(docs, "\n---\n") + "\n", nil
 }
 
+// encodeManifest serializes resources and verifies the result reads back before anyone
+// stores it. Cheap assertion on a novel code path: every other manifest write stores a
+// string DecodeAllYAML had just parsed, while encodeResources serializes afresh, and
+// these writes replace an existing record - so never overwrite a readable manifest with
+// something that cannot be read back.
+func encodeManifest(list []k8s.Resource) (string, error) {
+	var value string
+	var err error
+	if value, err = encodeResources(list); err != nil {
+		return "", fmt.Errorf("failed to encode manifest: %w", err)
+	}
+	var decoded []k8s.Resource
+	if decoded, err = k8s.DecodeAllYAML(value); err != nil {
+		return "", fmt.Errorf("manifest does not round-trip: %w", err)
+	}
+	if len(decoded) != len(list) {
+		return "", fmt.Errorf("manifest round-trips to %d of %d resources", len(decoded), len(list))
+	}
+	return value, nil
+}
+
+// resourcesFor picks the recorded resources matching the given removals.
+//
+// Removals carrying a rotation suffix have no manifest entry of their own - the manifest
+// holds the canonical StatefulSet name - so they simply do not match, which is correct.
+func resourcesFor(recorded []k8s.Resource, removals []toRemove) []k8s.Resource {
+	if len(removals) == 0 {
+		return nil
+	}
+	wanted := map[string]bool{}
+	for _, r := range removals {
+		wanted[r.namespace+"/"+resourceKey(r.kind, r.name)] = true
+	}
+	var kept []k8s.Resource
+	for _, r := range recorded {
+		if wanted[manifestKey(r)] {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
 // recordPartialManifest persists what is known to exist after a failed rollout, so that a
 // later uninstall can still clean it up and a retry still sees the un-applied resources as
 // changed. Best effort: failures here are logged, never returned, so they cannot mask the
@@ -429,20 +488,8 @@ func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resourc
 	}
 	var value string
 	var err error
-	if value, err = encodeResources(merged); err != nil {
-		rc.Logger().Warnf("failed to encode partial manifest for %s/%s: %s", rc.Namespace(), name, err)
-		return
-	}
-	// Cheap assertion on a novel code path, not a fix for any input we can produce.
-	// Every other manifest write stores a string DecodeAllYAML had just parsed -
-	// GenManifest decodes helm's output, getExistingManifest decodes the stored copy -
-	// so it is known readable. encodeResources is the one route that serializes afresh,
-	// and this write replaces the existing record, so do not overwrite a readable
-	// manifest with something that cannot be read back.
-	var decoded []k8s.Resource
-	if decoded, err = k8s.DecodeAllYAML(value); err != nil || len(decoded) != len(merged) {
-		rc.Logger().Warnf("partial manifest for %s/%s does not round-trip (%d of %d resources, err: %v), leaving the existing manifest untouched",
-			rc.Namespace(), name, len(decoded), len(merged), err)
+	if value, err = encodeManifest(merged); err != nil {
+		rc.Logger().Warnf("not recording partial manifest for %s/%s, leaving the existing one untouched: %s", rc.Namespace(), name, err)
 		return
 	}
 	// Detach from the rollout's context. A cancelled or timed out context is itself a
@@ -495,7 +542,10 @@ func renameStss(list []k8s.Resource, stsNameToRealName map[string]string) {
 // The returned resources are the *canonical* ones, i.e. the pre-renameStss form, because
 // that is how the manifest ConfigMap is keyed. Callers use them to record what actually
 // landed when the rollout only partially succeeds.
-func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, wait time.Duration, changed map[string]bool) (applied []k8s.Resource, err error) {
+// It also reports the removals that failed. Those resources are still in the cluster, so
+// dropping them from the manifest - as writing the new desired manifest alone would -
+// would leave nothing tracking them and they would leak permanently.
+func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, wait time.Duration, changed map[string]bool) (applied []k8s.Resource, failedRemovals []toRemove, err error) {
 	// Snapshot before renameStss, which replaces StatefulSet entries in `new` with
 	// renamed copies. Index correspondence is preserved because it assigns in place.
 	canonical := make([]k8s.Resource, len(new))
@@ -543,8 +593,9 @@ func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, 
 	}
 
 	for _, r := range toRemoves {
-		if err = k8s.Remove(rc.Context(), r.name, r.namespace, r.kind, k8s.WithWait(2*time.Minute)); err != nil {
+		if err = doRemove(rc.Context(), r.name, r.namespace, r.kind, k8s.WithWait(2*time.Minute)); err != nil {
 			rc.Logger().Warnf("failed to remove %s-%s/%s: %s", r.kind, r.namespace, r.name, err)
+			failedRemovals = append(failedRemovals, r)
 		}
 	}
 	err = nil

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -354,6 +354,9 @@ var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.Ope
 // decodeAllYAML is a seam over k8s.DecodeAllYAML for the round trip check below.
 var decodeAllYAML = k8s.DecodeAllYAML
 
+// manifestWriteTimeout bounds the detached write of a partial manifest.
+const manifestWriteTimeout = 30 * time.Second
+
 // mergeResources overlays applied on top of old, keyed by namespace+kind+name.
 //
 // Resources that were never applied stay at their old recorded form, which is exactly
@@ -450,7 +453,13 @@ func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resourc
 			return
 		}
 	}
-	if err = writeManifest(rc.Context(), value, name, rc.Namespace()); err != nil {
+	// Detach from the rollout's context. A cancelled or timed out context is itself a
+	// reason a rollout fails, and inheriting it here would mean the one case where the
+	// record matters most is the one case it never gets written. Values are preserved,
+	// only cancellation is dropped.
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(rc.Context()), manifestWriteTimeout)
+	defer cancel()
+	if err = writeManifest(writeCtx, value, name, rc.Namespace()); err != nil {
 		rc.Logger().Warnf("failed to write partial manifest for %s/%s: %s", rc.Namespace(), name, err)
 		return
 	}

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -48,11 +48,14 @@ var getExistingManifest = func(ctx context.Context, name, namespace string) (exi
 	return
 }
 
-func getManifests(ctx context.Context, chartPath string, values raw.Map) (old []k8s.Resource, new []k8s.Resource, newMap map[string]*k8s.Resource, newStr string, err error) {
+// getManifests renders the chart and loads the previously recorded manifest. It also
+// returns the release name it read them under, so that whatever writes the manifest back
+// keys it identically - deriving that name twice is how reads and writes drift apart.
+func getManifests(ctx context.Context, chartPath string, values raw.Map) (name string, old []k8s.Resource, new []k8s.Resource, newMap map[string]*k8s.Resource, newStr string, err error) {
 	if new, newStr, err = k8s.GenManifest(ctx, chartPath, values); err != nil {
 		return
 	}
-	var name, namespace string
+	var namespace string
 	if name, err = raw.ChainGet[string](values, "global", "name"); err != nil {
 		return
 	}
@@ -288,19 +291,17 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 	var old, new []k8s.Resource
 	var newMap map[string]*k8s.Resource
 	var newStr string
-	if old, new, newMap, newStr, err = getManifests(rc.Context(), chartPath, values); err != nil {
+	// manifestName is the release name getManifests just read the existing manifest
+	// under, so writes below land where the next read will look. new[0].GetName() is not
+	// a safe substitute: helm does not guarantee the first rendered object is named
+	// exactly global.name, and a chart whose first resource is e.g. "<release>-sa" would
+	// have its manifest written somewhere nothing looks for it.
+	var manifestName string
+	if manifestName, old, new, newMap, newStr, err = getManifests(rc.Context(), chartPath, values); err != nil {
 		return err
 	}
 	if len(new) == 0 {
 		return fmt.Errorf("nothing to rollout")
-	}
-	// The release name, which is what getExistingManifest and Remove key their reads by.
-	// new[0].GetName() is not a safe substitute: helm does not guarantee the first
-	// rendered object is named exactly global.name, and a chart whose first resource is
-	// e.g. "<release>-sa" would have its manifest written somewhere nothing looks.
-	var manifestName string
-	if manifestName, err = raw.ChainGet[string](values, "global", "name"); err != nil {
-		return err
 	}
 
 	var toRemoves []toRemove

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -351,6 +351,9 @@ var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.Ope
 	return k8s.Rollout(ctx, r, options...)
 }
 
+// decodeAllYAML is a seam over k8s.DecodeAllYAML for the round trip check below.
+var decodeAllYAML = k8s.DecodeAllYAML
+
 // mergeResources overlays applied on top of old, keyed by namespace+kind+name.
 //
 // Resources that were never applied stay at their old recorded form, which is exactly
@@ -361,11 +364,16 @@ var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.Ope
 // The namespace is part of the key even though resourceKey elsewhere ignores it: this
 // rewrites the manifest, so collapsing two same-named resources from different namespaces
 // would silently drop one of them and leak it forever.
+// manifestKey identifies a resource within a manifest document set.
+func manifestKey(r k8s.Resource) string {
+	return r.GetNamespace() + "/" + resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+}
+
 func mergeResources(old, applied []k8s.Resource) []k8s.Resource {
 	var merged []k8s.Resource
 	index := map[string]int{}
 	var add = func(r k8s.Resource) {
-		key := r.GetNamespace() + "/" + resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+		key := manifestKey(r)
 		if i, ok := index[key]; ok {
 			merged[i] = r
 			return
@@ -427,10 +435,20 @@ func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resourc
 	// Never replace a readable manifest with one that cannot be read back: uninstall
 	// would then fail to decode it and delete nothing at all.
 	var decoded []k8s.Resource
-	if decoded, err = k8s.DecodeAllYAML(value); err != nil || len(decoded) != len(merged) {
+	if decoded, err = decodeAllYAML(value); err != nil || len(decoded) != len(merged) {
 		rc.Logger().Warnf("partial manifest for %s/%s does not round-trip (%d of %d resources, err: %v), leaving the existing manifest untouched",
 			rc.Namespace(), name, len(decoded), len(merged), err)
 		return
+	}
+	// Matching counts alone is not enough: a stray "---" can split one document into
+	// fragments while another is dropped as empty, landing back on the same total. What
+	// uninstall acts on is each document's identity, so verify those.
+	for i, r := range decoded {
+		if manifestKey(r) != manifestKey(merged[i]) {
+			rc.Logger().Warnf("partial manifest for %s/%s round-trips to different resources (%s != %s), leaving the existing manifest untouched",
+				rc.Namespace(), name, manifestKey(r), manifestKey(merged[i]))
+			return
+		}
 	}
 	if err = writeManifest(rc.Context(), value, name, rc.Namespace()); err != nil {
 		rc.Logger().Warnf("failed to write partial manifest for %s/%s: %s", rc.Namespace(), name, err)

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -345,23 +345,7 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 		recordPartialManifest(rc, old, applied, manifestName)
 		return err
 	}
-	// A resource whose deletion failed is still running, so it has to stay in the
-	// manifest. Writing the desired manifest alone would drop it, and nothing would ever
-	// delete it again. On success `applied` is every rendered resource in canonical
-	// form, so the two merge cleanly.
-	if kept := resourcesFor(old, failedRemovals); len(kept) > 0 {
-		var value string
-		if value, err = encodeManifest(mergeResources(applied, kept)); err != nil {
-			// Fall back to the desired manifest, which is what would have been written
-			// before this existed. The failed removals leak, but adds stay tracked.
-			rc.Logger().Warnf("could not record %d resource(s) whose removal failed for %s/%s, they will no longer be tracked: %s",
-				len(kept), rc.Namespace(), manifestName, err)
-		} else {
-			rc.Logger().Infof("keeping %d resource(s) whose removal failed in the manifest for %s/%s", len(kept), rc.Namespace(), manifestName)
-			return writeManifest(rc.Context(), value, manifestName, rc.Namespace())
-		}
-	}
-	return writeManifest(rc.Context(), newStr, manifestName, rc.Namespace())
+	return writeManifest(rc.Context(), finalManifest(rc, old, applied, failedRemovals, newStr, manifestName), manifestName, rc.Namespace())
 }
 
 // applyResource is a seam over k8s.Rollout so that tests can drive partial failures.
@@ -475,6 +459,32 @@ func resourcesFor(recorded []k8s.Resource, removals []toRemove) []k8s.Resource {
 		}
 	}
 	return kept
+}
+
+// finalManifest returns the manifest to record after a successful rollout.
+//
+// Normally that is the rendered manifest verbatim. When a removal failed, though, the
+// resource is still running, and the rendered manifest no longer mentions it - nothing
+// would ever delete it again - so it is merged back in. On success `applied` is every
+// rendered resource in canonical form, so the two merge cleanly.
+//
+// Falls back to the rendered manifest if that cannot be encoded, which is what would have
+// been written before this existed: the failed removals stop being tracked, but
+// everything else stays correct.
+func finalManifest(rc global.ResourceContext, old, applied []k8s.Resource, failedRemovals []toRemove, rendered, name string) string {
+	kept := resourcesFor(old, failedRemovals)
+	if len(kept) == 0 {
+		return rendered
+	}
+	var value string
+	var err error
+	if value, err = encodeManifest(mergeResources(applied, kept)); err != nil {
+		rc.Logger().Warnf("could not record %d resource(s) whose removal failed for %s/%s, they will no longer be tracked: %s",
+			len(kept), rc.Namespace(), name, err)
+		return rendered
+	}
+	rc.Logger().Infof("keeping %d resource(s) whose removal failed in the manifest for %s/%s", len(kept), rc.Namespace(), name)
+	return value
 }
 
 // recordPartialManifest persists what is known to exist after a failed rollout, so that a

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -338,7 +338,7 @@ func Rollout(rc global.ResourceContext, chartPath string, values raw.Map, option
 		recordPartialManifest(rc, old, applied, manifestName)
 		return err
 	}
-	return writeManifest(rc.Context(), newStr, new[0].GetName(), rc.Namespace())
+	return writeManifest(rc.Context(), newStr, manifestName, rc.Namespace())
 }
 
 // applyResource is a seam over k8s.Rollout so that tests can drive partial failures.
@@ -346,17 +346,21 @@ var applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.Ope
 	return k8s.Rollout(ctx, r, options...)
 }
 
-// mergeResources overlays applied on top of old, keyed by kind+name.
+// mergeResources overlays applied on top of old, keyed by namespace+kind+name.
 //
 // Resources that were never applied stay at their old recorded form, which is exactly
 // what is still running in the cluster: an update that failed leaves the previous object
 // intact, and a resource that was never reached was never touched. Old resources that are
 // absent from applied are kept so that uninstall still removes them.
+//
+// The namespace is part of the key even though resourceKey elsewhere ignores it: this
+// rewrites the manifest, so collapsing two same-named resources from different namespaces
+// would silently drop one of them and leak it forever.
 func mergeResources(old, applied []k8s.Resource) []k8s.Resource {
 	var merged []k8s.Resource
 	index := map[string]int{}
 	var add = func(r k8s.Resource) {
-		key := resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
+		key := r.GetNamespace() + "/" + resourceKey(r.GetObjectKind().GroupVersionKind().Kind, r.GetName())
 		if i, ok := index[key]; ok {
 			merged[i] = r
 			return
@@ -492,6 +496,15 @@ func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, 
 		}
 		rc.Logger().Debugf(`applyManifest going for item: %s,conditons: %t,%t`, key, didChange, exists)
 		if err = applyResource(rc.Context(), r, k8s.WithWait(wait)); err != nil {
+			// k8s.Rollout creates or updates before it waits for readiness, so when a
+			// wait was requested the object may well exist despite this error. Record
+			// such a resource if it is new to us: an entry for something absent is
+			// harmless to uninstall, which only warns, while a missing entry leaks.
+			// Resources already in the recorded manifest are deliberately left at their
+			// old form so a retry still sees them as changed.
+			if wait > 0 && !exists {
+				applied = append(applied, canonical[i])
+			}
 			return
 		}
 		applied = append(applied, canonical[i])

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -501,8 +501,12 @@ func apply(rc global.ResourceContext, new []k8s.Resource, toRemoves []toRemove, 
 			// such a resource if it is new to us: an entry for something absent is
 			// harmless to uninstall, which only warns, while a missing entry leaks.
 			// Resources already in the recorded manifest are deliberately left at their
-			// old form so a retry still sees them as changed.
-			if wait > 0 && !exists {
+			// old form so a retry still diffs against what is really deployed.
+			//
+			// The lookup uses the canonical name: `key` above is the post-renameStss
+			// name, which for a StatefulSet never matches the canonical name `changed`
+			// was populated under, so it would report every StatefulSet as new.
+			if _, known := changed[resourceKey(kind, canonical[i].GetName())]; wait > 0 && !known {
 				applied = append(applied, canonical[i])
 			}
 			return

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -436,10 +436,13 @@ func recordPartialManifest(rc global.ResourceContext, old, applied []k8s.Resourc
 		rc.Logger().Warnf("failed to encode partial manifest for %s/%s: %s", rc.Namespace(), name, err)
 		return
 	}
-	// DecodeAllYAML splits on the substring "---", so a resource carrying one in its
-	// content - a PEM block, an embedded manifest - does not survive the round trip.
-	// Never replace a readable manifest with one that cannot be read back: uninstall
-	// would then fail to decode it and delete nothing at all.
+	// Sanity check, not a fix for a known input. Every other manifest write stores a
+	// string DecodeAllYAML had just parsed successfully - GenManifest decodes helm's
+	// output, getExistingManifest decodes the stored copy - so the text is proven
+	// readable before it is stored. encodeResources is the one route that generates
+	// manifest text afresh, and this write replaces the existing record, so confirm it
+	// reads back before destroying what is already there. DecodeAllYAML splits on the
+	// substring "---", so a value that re-marshals to contain one would not survive.
 	var decoded []k8s.Resource
 	if decoded, err = decodeAllYAML(value); err != nil || len(decoded) != len(merged) {
 		rc.Logger().Warnf("partial manifest for %s/%s does not round-trip (%d of %d resources, err: %v), leaving the existing manifest untouched",

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -328,9 +328,10 @@ spec:
 	assert.Equal(t, "sts1", applied[0].GetName())
 }
 
-func TestApplyRecordsNewResourceThatMayExistAfterWaitFailure(t *testing.T) {
-	// k8s.Rollout creates before it waits, so with wait > 0 a failure can leave the
-	// object behind. A brand new resource must still be recorded or it leaks.
+func TestApplyNeverRecordsAFailedResource(t *testing.T) {
+	// Recording a resource we did not manage to apply would make the next rollout diff
+	// it against itself, skip it, and report success while it stays missing. That holds
+	// whether or not a readiness wait was requested.
 	svc, err := k8s.DecodeYAML("kind: Service\nmetadata:\n  name: svc1\nspec:\n  ports:\n  - port: 1")
 	if err != nil {
 		panic(err)
@@ -338,48 +339,35 @@ func TestApplyRecordsNewResourceThatMayExistAfterWaitFailure(t *testing.T) {
 	orgApplyResource := applyResource
 	defer func() { applyResource = orgApplyResource }()
 	applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.OperationOption) error {
-		return fmt.Errorf("timed out waiting for readiness")
+		return fmt.Errorf("admission webhook denied the request")
 	}
 	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
 
-	applied, err := apply(rc, []k8s.Resource{svc}, nil, time.Minute, map[string]bool{})
-	assert.Error(t, err)
-	assert.Len(t, applied, 1, "new resource must be recorded when a wait was requested")
-
-	// With no wait there is no readiness phase, so a failure means nothing was created.
-	applied, err = apply(rc, []k8s.Resource{svc}, nil, 0, map[string]bool{})
-	assert.Error(t, err)
-	assert.Len(t, applied, 0, "without a wait a failure means the object was not created")
-
-	// A resource already in the recorded manifest stays at its old form so that a retry
-	// still sees it as changed.
-	applied, err = apply(rc, []k8s.Resource{svc}, nil, time.Minute, map[string]bool{
-		resourceKey(string(k8s.KindService), "svc1"): true,
-	})
-	assert.Error(t, err)
-	assert.Len(t, applied, 0, "known resources must not be overwritten with the new form")
+	for _, wait := range []time.Duration{0, time.Minute} {
+		applied, err := apply(rc, []k8s.Resource{svc}, nil, wait, map[string]bool{})
+		assert.Error(t, err)
+		assert.Len(t, applied, 0, "a resource that failed to apply must not be recorded")
+	}
 }
 
-func TestApplyWaitFailureUsesCanonicalNameForKnownStatefulSet(t *testing.T) {
-	// `changed` is keyed by the canonical name, but the loop key is the post-renameStss
-	// name. Looking up the renamed key would report an already-recorded StatefulSet as
-	// new and overwrite its old recorded form.
-	sts, err := k8s.DecodeYAML("kind: StatefulSet\nmetadata:\n  name: sts1\nspec:\n  replicas: 1\n  template:\n    spec:\n      containers:\n      - image: whocares")
+func TestRecordPartialManifestSkipsContentThatCannotRoundTrip(t *testing.T) {
+	// DecodeAllYAML splits on the substring "---", so a PEM block inside a ConfigMap
+	// does not survive. Overwriting a readable manifest with that would leave uninstall
+	// unable to decode anything and delete nothing.
+	cm, err := k8s.DecodeYAML("kind: ConfigMap\nmetadata:\n  name: cm1\ndata:\n  cert: |\n    -----BEGIN CERTIFICATE-----\n    abc\n    -----END CERTIFICATE-----\n")
 	if err != nil {
 		panic(err)
 	}
-	orgApplyResource := applyResource
-	defer func() { applyResource = orgApplyResource }()
-	applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.OperationOption) error {
-		return fmt.Errorf("timed out waiting for readiness")
+	orgWriteManifest := writeManifest
+	defer func() { writeManifest = orgWriteManifest }()
+	var called bool
+	writeManifest = func(ctx context.Context, value, name, namespace string) error {
+		called = true
+		return nil
 	}
 	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
-
-	applied, err := apply(rc, []k8s.Resource{sts}, nil, time.Minute, map[string]bool{
-		resourceKey(string(k8s.KindStatefulSet), "sts1"): true,
-	})
-	assert.Error(t, err)
-	assert.Len(t, applied, 0, "a StatefulSet already in the manifest must keep its old recorded form")
+	recordPartialManifest(rc, nil, []k8s.Resource{cm}, "release1")
+	assert.False(t, called, "must not overwrite the existing manifest with unreadable content")
 }
 
 func TestMergeResourcesKeepsSameNameAcrossNamespaces(t *testing.T) {

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/nextbillion-ai/goreman-util/global"
 	"github.com/sirupsen/logrus"
@@ -325,6 +326,57 @@ spec:
 	assert.Error(t, err)
 	assert.Len(t, applied, 1)
 	assert.Equal(t, "sts1", applied[0].GetName())
+}
+
+func TestApplyRecordsNewResourceThatMayExistAfterWaitFailure(t *testing.T) {
+	// k8s.Rollout creates before it waits, so with wait > 0 a failure can leave the
+	// object behind. A brand new resource must still be recorded or it leaks.
+	svc, err := k8s.DecodeYAML("kind: Service\nmetadata:\n  name: svc1\nspec:\n  ports:\n  - port: 1")
+	if err != nil {
+		panic(err)
+	}
+	orgApplyResource := applyResource
+	defer func() { applyResource = orgApplyResource }()
+	applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.OperationOption) error {
+		return fmt.Errorf("timed out waiting for readiness")
+	}
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+
+	applied, err := apply(rc, []k8s.Resource{svc}, nil, time.Minute, map[string]bool{})
+	assert.Error(t, err)
+	assert.Len(t, applied, 1, "new resource must be recorded when a wait was requested")
+
+	// With no wait there is no readiness phase, so a failure means nothing was created.
+	applied, err = apply(rc, []k8s.Resource{svc}, nil, 0, map[string]bool{})
+	assert.Error(t, err)
+	assert.Len(t, applied, 0, "without a wait a failure means the object was not created")
+
+	// A resource already in the recorded manifest stays at its old form so that a retry
+	// still sees it as changed.
+	applied, err = apply(rc, []k8s.Resource{svc}, nil, time.Minute, map[string]bool{
+		resourceKey(string(k8s.KindService), "svc1"): true,
+	})
+	assert.Error(t, err)
+	assert.Len(t, applied, 0, "known resources must not be overwritten with the new form")
+}
+
+func TestMergeResourcesKeepsSameNameAcrossNamespaces(t *testing.T) {
+	decode := func(y string) k8s.Resource {
+		r, err := k8s.DecodeYAML(y)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	// Same kind and name, different namespaces: collapsing them would drop one from the
+	// rewritten manifest and leak it.
+	svcA := decode("kind: Service\nmetadata:\n  name: shared\n  namespace: a")
+	svcB := decode("kind: Service\nmetadata:\n  name: shared\n  namespace: b")
+
+	merged := mergeResources([]k8s.Resource{svcA, svcB}, nil)
+	assert.Len(t, merged, 2)
+	assert.Equal(t, "a", merged[0].GetNamespace())
+	assert.Equal(t, "b", merged[1].GetNamespace())
 }
 
 func TestMergeResourcesOverlaysAppliedOnOld(t *testing.T) {

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -351,9 +351,10 @@ func TestApplyNeverRecordsAFailedResource(t *testing.T) {
 }
 
 func TestRecordPartialManifestSkipsContentThatCannotRoundTrip(t *testing.T) {
-	// DecodeAllYAML splits on the substring "---", so a PEM block inside a ConfigMap
-	// does not survive. Overwriting a readable manifest with that would leave uninstall
-	// unable to decode anything and delete nothing.
+	// Exercises the guard with content that provably does not survive the round trip:
+	// DecodeAllYAML splits on the substring "---", so a PEM block does not come back.
+	// Such a chart would already fail earlier in GenManifest, which decodes helm's
+	// output, so this is the guard working rather than a reachable production input.
 	cm, err := k8s.DecodeYAML("kind: ConfigMap\nmetadata:\n  name: cm1\ndata:\n  cert: |\n    -----BEGIN CERTIFICATE-----\n    abc\n    -----END CERTIFICATE-----\n")
 	if err != nil {
 		panic(err)

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -2,6 +2,7 @@ package operation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/nextbillion-ai/goreman-util/global"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zhchang/goquiver/k8s"
 	"github.com/zhchang/goquiver/raw"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestShouldRenameHP(t *testing.T) {
@@ -277,6 +279,149 @@ spec:
 	r = list[0]
 	assert.Equal(t, "sts1---0", r.GetName())
 	assert.Equal(t, "sts1---0", nameMap["sts1"])
+}
+
+func TestApplyReportsCanonicalResourcesUpToFailure(t *testing.T) {
+	// A StatefulSet applies fine, then the Service is rejected. The StatefulSet must be
+	// reported under its canonical name, not the ---0 name renameStss gives it, because
+	// that is how the manifest is keyed.
+	var stsYaml = `
+kind: StatefulSet
+metadata:
+  name: sts1
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - image: whocares`
+	var svcYaml = `
+kind: Service
+metadata:
+  name: svc1
+spec:
+  ports:
+  - port: 8888`
+	var err error
+	var sts, svc k8s.Resource
+	if sts, err = k8s.DecodeYAML(stsYaml); err != nil {
+		panic(err)
+	}
+	if svc, err = k8s.DecodeYAML(svcYaml); err != nil {
+		panic(err)
+	}
+
+	orgApplyResource := applyResource
+	defer func() { applyResource = orgApplyResource }()
+	applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.OperationOption) error {
+		if r.GetObjectKind().GroupVersionKind().Kind == string(k8s.KindService) {
+			return fmt.Errorf("admission webhook denied the request")
+		}
+		return nil
+	}
+
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+	applied, err := apply(rc, []k8s.Resource{sts, svc}, nil, 0, map[string]bool{})
+	assert.Error(t, err)
+	assert.Len(t, applied, 1)
+	assert.Equal(t, "sts1", applied[0].GetName())
+}
+
+func TestMergeResourcesOverlaysAppliedOnOld(t *testing.T) {
+	decode := func(y string) k8s.Resource {
+		r, err := k8s.DecodeYAML(y)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	oldSvc := decode("kind: Service\nmetadata:\n  name: svc1\nspec:\n  ports:\n  - port: 1")
+	newSvc := decode("kind: Service\nmetadata:\n  name: svc1\nspec:\n  ports:\n  - port: 2")
+	oldCm := decode("kind: ConfigMap\nmetadata:\n  name: cm1\ndata:\n  a: b")
+
+	merged := mergeResources([]k8s.Resource{oldSvc, oldCm}, []k8s.Resource{newSvc})
+	// The applied Service replaces the old one; the untouched ConfigMap is retained so
+	// uninstall still removes it.
+	assert.Len(t, merged, 2)
+	assert.Equal(t, "svc1", merged[0].GetName())
+	assert.Equal(t, "cm1", merged[1].GetName())
+	ports, err := raw.ChainGet[[]any](merged[0].(*unstructured.Unstructured).UnstructuredContent(), "spec", "ports")
+	assert.NoError(t, err)
+	assert.Len(t, ports, 1)
+	assert.Equal(t, int64(2), ports[0].(map[string]any)["port"])
+}
+
+func TestEncodeResourcesDoesNotInjectDefaults(t *testing.T) {
+	// Encoding through typed structs would add spec.template.metadata.creationTimestamp
+	// and status, which read back as spurious diffs and can trigger an unwanted rotation.
+	var stsYaml = `
+kind: StatefulSet
+metadata:
+  name: sts1
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - image: whocares`
+	r, err := k8s.DecodeYAML(stsYaml)
+	if err != nil {
+		panic(err)
+	}
+	encoded, err := encodeResources([]k8s.Resource{r})
+	assert.NoError(t, err)
+	assert.NotContains(t, encoded, "creationTimestamp")
+	assert.NotContains(t, encoded, "status:")
+
+	// and it must round-trip through the same decoder Remove/getManifests use
+	back, err := k8s.DecodeAllYAML(encoded)
+	assert.NoError(t, err)
+	assert.Len(t, back, 1)
+	assert.Equal(t, "sts1", back[0].GetName())
+	assert.Equal(t, string(k8s.KindStatefulSet), back[0].GetObjectKind().GroupVersionKind().Kind)
+}
+
+func TestRecordPartialManifestWritesUnderReleaseName(t *testing.T) {
+	decode := func(y string) k8s.Resource {
+		r, err := k8s.DecodeYAML(y)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	oldCm := decode("kind: ConfigMap\nmetadata:\n  name: cm1\ndata:\n  a: b")
+	appliedSvc := decode("kind: Service\nmetadata:\n  name: svc1\nspec:\n  ports:\n  - port: 8888")
+
+	orgWriteManifest := writeManifest
+	defer func() { writeManifest = orgWriteManifest }()
+	var gotName, gotValue string
+	writeManifest = func(ctx context.Context, value, name, namespace string) error {
+		gotName, gotValue = name, value
+		return nil
+	}
+
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+	recordPartialManifest(rc, []k8s.Resource{oldCm}, []k8s.Resource{appliedSvc}, "release1")
+
+	assert.Equal(t, "release1", gotName)
+	written, err := k8s.DecodeAllYAML(gotValue)
+	assert.NoError(t, err)
+	assert.Len(t, written, 2)
+	assert.Equal(t, "cm1", written[0].GetName())
+	assert.Equal(t, "svc1", written[1].GetName())
+}
+
+func TestRecordPartialManifestSkipsWhenNothingToRecord(t *testing.T) {
+	orgWriteManifest := writeManifest
+	defer func() { writeManifest = orgWriteManifest }()
+	var called bool
+	writeManifest = func(ctx context.Context, value, name, namespace string) error {
+		called = true
+		return nil
+	}
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+	recordPartialManifest(rc, nil, nil, "release1")
+	assert.False(t, called)
 }
 
 func TestRemove(t *testing.T) {

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -360,6 +360,28 @@ func TestApplyRecordsNewResourceThatMayExistAfterWaitFailure(t *testing.T) {
 	assert.Len(t, applied, 0, "known resources must not be overwritten with the new form")
 }
 
+func TestApplyWaitFailureUsesCanonicalNameForKnownStatefulSet(t *testing.T) {
+	// `changed` is keyed by the canonical name, but the loop key is the post-renameStss
+	// name. Looking up the renamed key would report an already-recorded StatefulSet as
+	// new and overwrite its old recorded form.
+	sts, err := k8s.DecodeYAML("kind: StatefulSet\nmetadata:\n  name: sts1\nspec:\n  replicas: 1\n  template:\n    spec:\n      containers:\n      - image: whocares")
+	if err != nil {
+		panic(err)
+	}
+	orgApplyResource := applyResource
+	defer func() { applyResource = orgApplyResource }()
+	applyResource = func(ctx context.Context, r k8s.Resource, options ...k8s.OperationOption) error {
+		return fmt.Errorf("timed out waiting for readiness")
+	}
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+
+	applied, err := apply(rc, []k8s.Resource{sts}, nil, time.Minute, map[string]bool{
+		resourceKey(string(k8s.KindStatefulSet), "sts1"): true,
+	})
+	assert.Error(t, err)
+	assert.Len(t, applied, 0, "a StatefulSet already in the manifest must keep its old recorded form")
+}
+
 func TestMergeResourcesKeepsSameNameAcrossNamespaces(t *testing.T) {
 	decode := func(y string) k8s.Resource {
 		r, err := k8s.DecodeYAML(y)

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -322,7 +322,7 @@ spec:
 	}
 
 	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
-	applied, err := apply(rc, []k8s.Resource{sts, svc}, nil, 0, map[string]bool{})
+	applied, _, err := apply(rc, []k8s.Resource{sts, svc}, nil, 0, map[string]bool{})
 	assert.Error(t, err)
 	assert.Len(t, applied, 1)
 	assert.Equal(t, "sts1", applied[0].GetName())
@@ -344,7 +344,7 @@ func TestApplyNeverRecordsAFailedResource(t *testing.T) {
 	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
 
 	for _, wait := range []time.Duration{0, time.Minute} {
-		applied, err := apply(rc, []k8s.Resource{svc}, nil, wait, map[string]bool{})
+		applied, _, err := apply(rc, []k8s.Resource{svc}, nil, wait, map[string]bool{})
 		assert.Error(t, err)
 		assert.Len(t, applied, 0, "a resource that failed to apply must not be recorded")
 	}
@@ -392,6 +392,78 @@ func TestRecordPartialManifestWritesEvenWhenContextIsCancelled(t *testing.T) {
 	recordPartialManifest(rc, nil, []k8s.Resource{svc}, "release1")
 
 	assert.NoError(t, gotErr, "the write context must not carry the rollout's cancellation")
+}
+
+func TestApplyReportsFailedRemovals(t *testing.T) {
+	// A resource dropped from the chart whose deletion fails is still running. It has to
+	// be reported, or the caller writes a manifest that no longer mentions it and
+	// nothing ever deletes it again.
+	orgDoRemove := doRemove
+	defer func() { doRemove = orgDoRemove }()
+	doRemove = func(ctx context.Context, name, namespace string, kind k8s.Kind, options ...k8s.OperationOption) error {
+		if name == "stuck" {
+			return fmt.Errorf("object has a finalizer")
+		}
+		return nil
+	}
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+
+	removals := []toRemove{
+		{name: "gone", namespace: "ns", kind: k8s.KindService},
+		{name: "stuck", namespace: "ns", kind: k8s.KindConfigMap},
+	}
+	applied, failed, err := apply(rc, nil, removals, 0, map[string]bool{})
+	assert.NoError(t, err, "a failed removal must not fail the rollout")
+	assert.Empty(t, applied)
+	assert.Len(t, failed, 1)
+	assert.Equal(t, "stuck", failed[0].name)
+}
+
+func TestResourcesForMatchesRemovalsByIdentity(t *testing.T) {
+	decode := func(y string) k8s.Resource {
+		r, err := k8s.DecodeYAML(y)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	cm := decode("kind: ConfigMap\nmetadata:\n  name: stuck\n  namespace: ns")
+	svc := decode("kind: Service\nmetadata:\n  name: other\n  namespace: ns")
+
+	kept := resourcesFor([]k8s.Resource{cm, svc}, []toRemove{
+		{name: "stuck", namespace: "ns", kind: k8s.KindConfigMap},
+	})
+	assert.Len(t, kept, 1)
+	assert.Equal(t, "stuck", kept[0].GetName())
+
+	// a same-named resource of a different kind must not match
+	kept = resourcesFor([]k8s.Resource{cm}, []toRemove{
+		{name: "stuck", namespace: "ns", kind: k8s.KindService},
+	})
+	assert.Empty(t, kept)
+
+	// a rotation-suffixed removal has no manifest entry, so it matches nothing
+	kept = resourcesFor([]k8s.Resource{cm}, []toRemove{
+		{name: "stuck---0", namespace: "ns", kind: k8s.KindStatefulSet},
+	})
+	assert.Empty(t, kept)
+}
+
+func TestEncodeManifestRejectsContentThatCannotRoundTrip(t *testing.T) {
+	cm, err := k8s.DecodeYAML("kind: ConfigMap\nmetadata:\n  name: cm1\ndata:\n  cert: |\n    -----BEGIN CERTIFICATE-----\n    abc\n    -----END CERTIFICATE-----\n")
+	if err != nil {
+		panic(err)
+	}
+	_, err = encodeManifest([]k8s.Resource{cm})
+	assert.Error(t, err)
+
+	svc, err := k8s.DecodeYAML("kind: Service\nmetadata:\n  name: svc1")
+	if err != nil {
+		panic(err)
+	}
+	value, err := encodeManifest([]k8s.Resource{svc})
+	assert.NoError(t, err)
+	assert.Contains(t, value, "svc1")
 }
 
 func TestMergeResourcesKeepsSameNameAcrossNamespaces(t *testing.T) {

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -451,7 +451,7 @@ func TestFinalManifest(t *testing.T) {
 	assert.Equal(t, "RENDERED", got)
 }
 
-func TestResourcesForMatchesRemovalsByIdentity(t *testing.T) {
+func TestResourcesMatchingByIdentity(t *testing.T) {
 	decode := func(y string) k8s.Resource {
 		r, err := k8s.DecodeYAML(y)
 		if err != nil {
@@ -462,20 +462,20 @@ func TestResourcesForMatchesRemovalsByIdentity(t *testing.T) {
 	cm := decode("kind: ConfigMap\nmetadata:\n  name: stuck\n  namespace: ns")
 	svc := decode("kind: Service\nmetadata:\n  name: other\n  namespace: ns")
 
-	kept := resourcesFor([]k8s.Resource{cm, svc}, []toRemove{
+	kept := resourcesMatching([]k8s.Resource{cm, svc}, []toRemove{
 		{name: "stuck", namespace: "ns", kind: k8s.KindConfigMap},
 	})
 	assert.Len(t, kept, 1)
 	assert.Equal(t, "stuck", kept[0].GetName())
 
 	// a same-named resource of a different kind must not match
-	kept = resourcesFor([]k8s.Resource{cm}, []toRemove{
+	kept = resourcesMatching([]k8s.Resource{cm}, []toRemove{
 		{name: "stuck", namespace: "ns", kind: k8s.KindService},
 	})
 	assert.Empty(t, kept)
 
 	// a rotation-suffixed removal has no manifest entry, so it matches nothing
-	kept = resourcesFor([]k8s.Resource{cm}, []toRemove{
+	kept = resourcesMatching([]k8s.Resource{cm}, []toRemove{
 		{name: "stuck---0", namespace: "ns", kind: k8s.KindStatefulSet},
 	})
 	assert.Empty(t, kept)

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -394,38 +394,6 @@ func TestRecordPartialManifestWritesEvenWhenContextIsCancelled(t *testing.T) {
 	assert.NoError(t, gotErr, "the write context must not carry the rollout's cancellation")
 }
 
-func TestRecordPartialManifestSkipsWhenIdentitiesShift(t *testing.T) {
-	// A stray "---" can split one document while another is dropped as empty, leaving
-	// the count intact but the identities wrong. Uninstall acts on the identities.
-	decode := func(y string) k8s.Resource {
-		r, err := k8s.DecodeYAML(y)
-		if err != nil {
-			panic(err)
-		}
-		return r
-	}
-	svc := decode("kind: Service\nmetadata:\n  name: svc1")
-	cm := decode("kind: ConfigMap\nmetadata:\n  name: cm1")
-
-	orgDecodeAll := decodeAllYAML
-	defer func() { decodeAllYAML = orgDecodeAll }()
-	decodeAllYAML = func(value string) ([]k8s.Resource, error) {
-		// same count, different identities
-		return []k8s.Resource{decode("kind: Service\nmetadata:\n  name: other"), cm}, nil
-	}
-
-	orgWriteManifest := writeManifest
-	defer func() { writeManifest = orgWriteManifest }()
-	var called bool
-	writeManifest = func(ctx context.Context, value, name, namespace string) error {
-		called = true
-		return nil
-	}
-	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
-	recordPartialManifest(rc, nil, []k8s.Resource{svc, cm}, "release1")
-	assert.False(t, called, "must not write when the round trip yields different resources")
-}
-
 func TestMergeResourcesKeepsSameNameAcrossNamespaces(t *testing.T) {
 	decode := func(y string) k8s.Resource {
 		r, err := k8s.DecodeYAML(y)

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -419,6 +419,38 @@ func TestApplyReportsFailedRemovals(t *testing.T) {
 	assert.Equal(t, "stuck", failed[0].name)
 }
 
+func TestFinalManifest(t *testing.T) {
+	decode := func(y string) k8s.Resource {
+		r, err := k8s.DecodeYAML(y)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	svc := decode("kind: Service\nmetadata:\n  name: svc1\n  namespace: ns")
+	stuck := decode("kind: ConfigMap\nmetadata:\n  name: stuck\n  namespace: ns")
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+
+	// nothing failed: the rendered manifest is stored verbatim
+	got := finalManifest(rc, []k8s.Resource{svc, stuck}, []k8s.Resource{svc}, nil, "RENDERED", "release1")
+	assert.Equal(t, "RENDERED", got)
+
+	// a removal failed: the resource is merged back in so it stays tracked
+	got = finalManifest(rc, []k8s.Resource{svc, stuck}, []k8s.Resource{svc},
+		[]toRemove{{name: "stuck", namespace: "ns", kind: k8s.KindConfigMap}}, "RENDERED", "release1")
+	assert.NotEqual(t, "RENDERED", got)
+	back, err := k8s.DecodeAllYAML(got)
+	assert.NoError(t, err)
+	assert.Len(t, back, 2)
+	assert.Equal(t, "svc1", back[0].GetName())
+	assert.Equal(t, "stuck", back[1].GetName())
+
+	// a removal that matches nothing recorded leaves the rendered manifest alone
+	got = finalManifest(rc, []k8s.Resource{svc}, []k8s.Resource{svc},
+		[]toRemove{{name: "sts1---0", namespace: "ns", kind: k8s.KindStatefulSet}}, "RENDERED", "release1")
+	assert.Equal(t, "RENDERED", got)
+}
+
 func TestResourcesForMatchesRemovalsByIdentity(t *testing.T) {
 	decode := func(y string) k8s.Resource {
 		r, err := k8s.DecodeYAML(y)

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -370,6 +370,29 @@ func TestRecordPartialManifestSkipsContentThatCannotRoundTrip(t *testing.T) {
 	assert.False(t, called, "must not overwrite the existing manifest with unreadable content")
 }
 
+func TestRecordPartialManifestWritesEvenWhenContextIsCancelled(t *testing.T) {
+	// A cancelled or timed out context is itself a reason a rollout fails, and that is
+	// exactly when the record matters. The write must not inherit the cancellation.
+	svc, err := k8s.DecodeYAML("kind: Service\nmetadata:\n  name: svc1")
+	if err != nil {
+		panic(err)
+	}
+	orgWriteManifest := writeManifest
+	defer func() { writeManifest = orgWriteManifest }()
+	var gotErr error
+	writeManifest = func(ctx context.Context, value, name, namespace string) error {
+		gotErr = ctx.Err()
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rc := global.NewContext(ctx, global.WithLogLevel(logrus.ErrorLevel))
+	recordPartialManifest(rc, nil, []k8s.Resource{svc}, "release1")
+
+	assert.NoError(t, gotErr, "the write context must not carry the rollout's cancellation")
+}
+
 func TestRecordPartialManifestSkipsWhenIdentitiesShift(t *testing.T) {
 	// A stray "---" can split one document while another is dropped as empty, leaving
 	// the count intact but the identities wrong. Uninstall acts on the identities.

--- a/operation/operation_test.go
+++ b/operation/operation_test.go
@@ -370,6 +370,38 @@ func TestRecordPartialManifestSkipsContentThatCannotRoundTrip(t *testing.T) {
 	assert.False(t, called, "must not overwrite the existing manifest with unreadable content")
 }
 
+func TestRecordPartialManifestSkipsWhenIdentitiesShift(t *testing.T) {
+	// A stray "---" can split one document while another is dropped as empty, leaving
+	// the count intact but the identities wrong. Uninstall acts on the identities.
+	decode := func(y string) k8s.Resource {
+		r, err := k8s.DecodeYAML(y)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	svc := decode("kind: Service\nmetadata:\n  name: svc1")
+	cm := decode("kind: ConfigMap\nmetadata:\n  name: cm1")
+
+	orgDecodeAll := decodeAllYAML
+	defer func() { decodeAllYAML = orgDecodeAll }()
+	decodeAllYAML = func(value string) ([]k8s.Resource, error) {
+		// same count, different identities
+		return []k8s.Resource{decode("kind: Service\nmetadata:\n  name: other"), cm}, nil
+	}
+
+	orgWriteManifest := writeManifest
+	defer func() { writeManifest = orgWriteManifest }()
+	var called bool
+	writeManifest = func(ctx context.Context, value, name, namespace string) error {
+		called = true
+		return nil
+	}
+	rc := global.NewContext(context.Background(), global.WithLogLevel(logrus.ErrorLevel))
+	recordPartialManifest(rc, nil, []k8s.Resource{svc, cm}, "release1")
+	assert.False(t, called, "must not write when the round trip yields different resources")
+}
+
 func TestMergeResourcesKeepsSameNameAcrossNamespaces(t *testing.T) {
 	decode := func(y string) k8s.Resource {
 		r, err := k8s.DecodeYAML(y)


### PR DESCRIPTION
## Problem

`Rollout` writes the `<name>-manifest` ConfigMap only after `apply` fully succeeds ([operation.go:333](https://github.com/nextbillion-ai/goreman-util/blob/main/operation/operation.go#L333)), but `apply` is not transactional — it returns on the first failed resource and leaves everything already applied in the cluster.

`Remove` then reads that ConfigMap first and returns immediately if it is missing, before deleting anything:

```go
if old, err = getExistingManifest(rc.Context(), name, namespace); err != nil {
    return err
}
```

So a partially-applied rollout becomes permanently uncleanable.

### Production incident

GKE Warden rejected a StatefulSet after its Service and ConfigMap had already been applied. No manifest was written, so every subsequent uninstall failed with `configmaps "<name>-manifest" not found` and deleted nothing. Each attempt leaked one more Service until the cluster's service IP range was exhausted:

```
foreman rollout failed. err: admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request
Failed to release idle podInfo:mdm-pd-nam-va-2377997013d failed to uninstall. error: configmaps "mdm-pd-nam-va-2377997013d-manifest" not found
foreman rollout failed. err: Internal error occurred: failed to allocate a serviceIP: range is full
```

865 orphaned Services had to be deleted by hand to restore the namespace.

Note the existing asymmetry this exploits: `getManifests` already tolerates a missing manifest on the rollout path ([:59-61](https://github.com/nextbillion-ai/goreman-util/blob/main/operation/operation.go#L59-L61), `err != nil { old = nil }`), while `Remove` treats it as fatal. The code already knows a resource can exist without a manifest record; only the create path handles it.

## Fix

Two paths let the manifest drift out of step with the cluster. Both are closed here, under one rule: **the manifest describes what exists.**

### 1. A rollout that fails partway

On the error path, record what is actually in the cluster: **the old manifest overlaid with the resources that were successfully applied**.

That keeps the manifest's meaning intact — "what exists" — which is what both consumers depend on:

- **uninstall** can now delete the partial rollout;
- **retry** still works, because un-applied resources stay at their old recorded form, so the `changed` diff-skip in `apply` still sees them as changed and does the remaining work.

### Why not simply write the manifest before `apply`

That fixes the leak but breaks retries. `apply` skips any resource whose key is in `changed` as false ([:486-490](https://github.com/nextbillion-ai/goreman-util/blob/main/operation/operation.go#L486-L490)). If the full desired manifest were written up front, a same-spec retry would compute an empty diff for every resource, skip them all, and `Rollout` would return success having deployed nothing.

It is worse than uniform skipping, too: `renameStss` renames the StatefulSet to `---0` before the key check, so its key no longer matches the `changed` entry and it *is* re-applied — while its Service is silently skipped. You would get a StatefulSet with no Service.

### 2. A deletion that fails

`apply` warned on a failed `k8s.Remove` and then cleared `err`, so `Rollout` reported success and wrote the desired manifest — which no longer mentions the resource that was supposed to be deleted. It was still running, but now appeared in no manifest, so no later `Remove` would ever delete it. Permanent leak, silently.

`apply` now reports which removals failed, and `finalManifest` merges those resources back into what gets written, so uninstall still knows about them and the next rollout retries the removal. Removals go through the `doRemove` seam `operation.Remove` already uses, which also makes the path testable.

## Implementation notes

- **Canonical names.** Recorded resources are the pre-`renameStss` form, since that is how the manifest is keyed. `apply` snapshots the slice before renaming; index correspondence holds because `renameStss` assigns in place. Recording the renamed `name---0` form instead would make `Remove` look up `getCurrentRotation("name---0")`, find nothing, and leak the StatefulSet.
- **Raw serialization.** Partial manifests are marshalled from raw unstructured content rather than through `k8s.EncodeYAMLAll`. Typed encoding injects defaulted fields — verified output adds `spec.selector: null`, `spec.serviceName: ""`, `spec.updateStrategy: {}` and `status`. Those are *spec-level*, so they read back as spurious diffs on the next rollout, and for a 1-replica StatefulSet `shouldRotate` returns true on any spec change beyond replicas-only ([:121-127](https://github.com/nextbillion-ai/goreman-util/blob/main/operation/operation.go#L121-L127)) — an unwanted rotation.
- **Best effort.** Encode/write failures are logged, never returned, so they cannot mask the rollout error that caused them.
- **Seams.** `applyResource` and `writeManifest` became package vars so the partial-failure path is testable, matching the existing `doRemove`/`getExistingManifest` pattern.

## Review findings, addressed in the follow-up commits

- **`mergeResources` collapsed same-named resources across namespaces.** It keyed on kind+name only. Since the partial manifest is a *rewrite*, a chart rendering `Service/shared` into two namespaces would have lost one permanently — worse than the old behaviour of leaving the manifest untouched. Now keyed by namespace+kind+name.
- **The two write paths disagreed on the manifest name.** The error path used the pre-rename name while the success path still used `new[0].GetName()` post-rename. Where the first rendered resource is a renamable StatefulSet, a failed-then-successful rollout would write `foo-manifest` then `foo---0-manifest`, and a later `Remove(foo)` would read the stale partial and leak whatever the retry applied. Both paths now use the pre-rename release name.
- **Wait-phase failures drop resources — deliberately left that way.** `k8s.Rollout` creates or updates *before* waiting for readiness, so a wait timeout leaves the object behind and it is not recorded. An attempt to record it (using `wait > 0` as a proxy for "may exist") was tried and then reverted: that case cannot be told apart from an admission or validation rejection where nothing was created, and recording something absent makes the next rollout diff it against itself, skip it, and report success while it stays missing. That is the exact failure this PR exists to prevent, so the stricter invariant wins — *recorded ⇒ known applied*. The residual gap is narrower and self-healing: the next successful rollout records the resource.

- **The manifest was named from `new[0].GetName()`.** Helm does not guarantee the first rendered object is named exactly `global.name`, so a chart leading with e.g. `<release>-sa` wrote its manifest where nothing looks for it. Now uses `values.global.name`, which is what `getExistingManifest` and `Remove` key their reads by. (This was pre-existing on the success path, not introduced here.)

- **A partial manifest could be unreadable.** `DecodeAllYAML` splits on the *substring* `---`, so a ConfigMap carrying a PEM block does not survive the round trip — verified to produce a decode error and zero documents. Writing that would replace a readable manifest with one uninstall cannot parse, leaving it unable to delete anything. `recordPartialManifest` now verifies the encoding decodes back to the same resource count and otherwise leaves the existing manifest untouched.

## Tests

Thirteen new tests (23 total in the package): canonical-name reporting on partial failure, overlay semantics, encoding fidelity (asserts no injected defaults + round-trips through `DecodeAllYAML`), and the record/skip paths. Full suite passes; `gofmt` clean.

## Not fixed here

Pre-existing issues found while tracing this, left alone to keep the change reviewable:

1. `rotateSts` writes the rotated StatefulSet back through `newMap`, whose entries are `&r` of a loop copy rather than `&new[i]` — the rename never reaches the slice `apply` iterates, so `renameStss` always produces `---0`.
2. The HPA branch in `apply` mutates a parsed copy (`hpa.Spec.ScaleTargetRef.Name`) but then rolls out the original `r`, discarding the change.
3. Rotation cleanup: `operation.Remove` deletes only the current rotation, so any older `name---N` StatefulSet left behind by a failed rotation removal stays orphaned. Unrelated to this change, but the same family.

Note the success path still stores helm's rendered manifest verbatim in the normal case — the encode-and-verify step only applies when a failed removal forces a merge.
